### PR TITLE
投稿ページの編集

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,9 @@ class ApplicationController < ActionController::Base
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
 
+  # フラッシュメッセージのタイプを追加
+  add_flash_types :success, :danger
+
   # ログイン後の遷移先を投稿作成ページに設定
   # deviseのデフォルトではルートページに設定されているため
   def after_sign_in_path_for(resource)

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -12,8 +12,7 @@ class PostsController < ApplicationController
     if @post.save
       redirect_to new_post_path, notice: "投稿に成功しました"
     else
-      flash.now[:alert] = "投稿に失敗しました"
-      render "new", status: :unprocessable_entity # Rails 7以降の推奨
+      render "new", status: :unprocessable_entity # Rails 7以降の推奨 HTTPステータスコード422を返す
     end
   end
 

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -20,6 +20,6 @@ class PostsController < ApplicationController
   private
 
   def post_params  # ストロングパラメータ
-    params.require(:post).permit(:thinking_topic) # パラメーターのキー
+    params.require(:post).permit(:thinking_topic, :thinking_diffusion, :thinking_core, :thinking_output) # パラメーターのキー
   end
 end

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -1,11 +1,24 @@
-<h1>思考の整理テーマ</h1>
-<p>考えたいテーマを入力してください。</p>
+<h1>思考の整理</h1>
+<p>今、気になっていることを整理してみませんか？</p>
 
 
 <%= form_with model: @post do |f| %>
   <div>
-    <%= f.label :thinking_topic %>
+    <%= f.label :thinking_topic, '整理したいテーマ' %>
     <%= f.text_field :thinking_topic %>
   </div>
-  <%= f.submit %>
+  <div>
+    <%= f.label :thinking_diffusion, '考えの箇条書き' %>
+    <%= f.text_area :thinking_diffusion %>
+  </div>
+  <div>
+    <%= f.label :thinking_core, '整理の目的' %>
+    <%= f.select :thinking_core, ['【報連相】 どう伝えればいいか整理したい', '【学び・感想】 記事や講演の内容を自分の血肉にしたい', '【会議・打合せ】 決まったことと次やることを明確にしたい', '【壁打ち】 モヤモヤしていることを言語化してほしい'], { include_blank: '選択してください' } %>
+  </div>
+  <div>
+    <%= f.label :thinking_output, '整理した考え' %>
+    <%= f.text_area :thinking_output %>
+  </div>
+
+  <%= f.submit '保存' %>
 <% end %>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -17,19 +17,19 @@
 
   <div>
     <%= f.label :thinking_topic, '整理したいテーマ' %>
-    <%= f.text_field :thinking_topic %>
+    <%= f.text_field :thinking_topic, class: "border border-gray-400 rounded px-3 py-2" %>
   </div>
   <div>
     <%= f.label :thinking_diffusion, '考えの箇条書き' %>
-    <%= f.text_area :thinking_diffusion %>
+    <%= f.text_area :thinking_diffusion, class: "border border-gray-400 rounded px-3 py-2" %>
   </div>
   <div>
     <%= f.label :thinking_core, '整理の目的' %>
-    <%= f.select :thinking_core, ['【報連相】 どう伝えればいいか整理したい', '【学び・感想】 記事や講演の内容を自分の血肉にしたい', '【会議・打合せ】 決まったことと次やることを明確にしたい', '【壁打ち】 モヤモヤしていることを言語化してほしい'], { include_blank: '選択してください' } %>
+    <%= f.select :thinking_core, ['【報連相】 どう伝えればいいか整理したい', '【学び・感想】 記事や講演の内容を自分の血肉にしたい', '【会議・打合せ】 決まったことと次やることを明確にしたい', '【壁打ち】 モヤモヤしていることを言語化してほしい'], { include_blank: '選択してください' }, class: "border border-gray-400 rounded px-3 py-2" %>
   </div>
   <div>
     <%= f.label :thinking_output, '整理した考え' %>
-    <%= f.text_area :thinking_output %>
+    <%= f.text_area :thinking_output, class: "border border-gray-400 rounded px-3 py-2" %>
   </div>
 
   <%= f.submit '保存' %>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -3,6 +3,18 @@
 
 
 <%= form_with model: @post do |f| %>
+  <%# --- エラーメッセージ表示 --- %>
+  <% if @post.errors.any? %>
+    <div id="error_explanation" class="text-red-500 border border-red-400 bg-red-50 p-4 mb-4 rounded">
+      <h2><%= @post.errors.count %> 件のエラーにより保存できませんでした：</h2>
+      <ul>
+        <% @post.errors.full_messages.each do |message| %>
+          <li>・<%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
   <div>
     <%= f.label :thinking_topic, '整理したいテーマ' %>
     <%= f.text_field :thinking_topic %>

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -1,9 +1,11 @@
 require 'rails_helper'
 
 RSpec.describe Post, type: :model do
-  # テストデータの準備（FactoryBotを使っている場合を想定）
-  let(:user) { User.create(email: "test@example.com", password: "password") }
-  let(:post) { Post.new(thinking_topic: "テストのテーマ", user: user) }
+  # テストデータの準備
+  # userを作成
+  let(:user) { FactoryBot.create(:user) }
+  # userに紐付いた未保存のpostを準備
+  let(:post) { FactoryBot.build(:post, user: user) }
 
   it "有効な属性を持っていれば保存できること" do
     expect(post).to be_valid

--- a/spec/support/login_macros.rb
+++ b/spec/support/login_macros.rb
@@ -4,5 +4,7 @@ module LoginMacros
     fill_in 'Email', with: user.email
     fill_in 'Password', with: 'password'
     click_on 'Log in'
+
+    expect(page).to have_content 'Signed in successfully.'
   end
 end

--- a/spec/system/posts_spec.rb
+++ b/spec/system/posts_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe "思考整理の投稿機能", type: :system do
+  include LoginMacros
+  let(:user) { FactoryBot.create(:user) }
+
+  before do
+    # ログインして投稿画面へ移動
+    login(user)
+  end
+
+  describe "新規投稿" do
+    context "入力内容が正しいとき" do
+      it "投稿が成功し、成功メッセージが表示されること" do
+        fill_in '整理したいテーマ', with: 'テストテーマ'
+        fill_in '考えの箇条書き', with: '考えのテスト内容'
+        select '【壁打ち】 モヤモヤしていることを言語化してほしい', from: '整理の目的'
+        fill_in '整理した考え', with: '整理後のテスト内容'
+        click_on '保存'
+        # 成功メッセージが表示されるのを待つ
+        expect(page).to have_content '投稿に成功しました'
+        # Postモデルのレコード数が増えたか確認
+        expect(Post.count).to eq 1
+        # 遷移先のURL確認（redirect_to new_post_path なので同じURL）
+        expect(page).to have_current_path(new_post_path)
+      end
+    end
+
+    context "入力内容に不備があるとき" do
+      it "保存に失敗し、エラーメッセージが表示されること" do
+        # テーマを空のままにする
+        fill_in '整理したいテーマ', with: ''
+        expect { click_on '保存' }.not_to change(Post, :count)
+        # エラーメッセージの確認（モデルのバリデーションメッセージ）
+        expect(page).to have_content "Thinking topic can't be blank"
+        # エラー表示エリアの文言確認
+        expect(page).to have_content '件のエラーにより保存できませんでした'
+      end
+    end
+  end
+end


### PR DESCRIPTION
# 概要
投稿作成ページを編集した。

## 背景・目的
MVP要件の見直しを行った際、画面遷移も調整し、投稿作成ページにフォームをまとめることにしたため。

## 実施内容
- ビューの編集 
  - 考えの箇条書き、整理の目的、整理した考えフォームを追加

- エラーメッセージの表示
  - バリデーションエラーが発生した際、画面上部にエラー内容がリスト表示されるようロジックを追加

- System Specテスト 
  - 正常な入力で投稿が成功し、成功メッセージが表示されることを確認
  - 入力不備がある場合に、エラーメッセージが表示され投稿に失敗することを確認

## 関連Issue
Closes #61