### PR TITLE
投稿一覧ページ作成

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -16,6 +16,10 @@ class PostsController < ApplicationController
     end
   end
 
+  def index
+    @posts = current_user.posts.includes(:user).order(created_at: :desc)
+  end
+
   private
 
   def post_params  # ストロングパラメータ

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -12,8 +12,8 @@
         <!-- ナビゲーションリンク (デスクトップ) -->
         <div class="ml-10 hidden space-x-8 lg:block">
         <% if user_signed_in? %>
-          <%= link_to "思考整理", "#", class: "text-base font-medium text-gray-500 hover:text-gray-900" %>
-          <%= link_to "思考一覧", "#", class: "text-base font-medium text-gray-500 hover:text-gray-900" %>
+          <%= link_to "思考整理", new_post_path, class: "text-base font-medium text-gray-500 hover:text-gray-900" %>
+          <%= link_to "思考一覧", posts_path, class: "text-base font-medium text-gray-500 hover:text-gray-900" %>
           <%= link_to "利用規約", "#", class: "text-base font-medium text-gray-500 hover:text-gray-900" %>
           <%= link_to "プライバシーポリシー", "#", class: "text-base font-medium text-gray-500 hover:text-gray-900" %>
         <% else %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,9 +1,13 @@
 <h1>整理した思考一覧</h1>
-<% @posts.each do |post| %>
-<li>
-  <%= post.thinking_topic %>
-  <%= post.thinking_diffusion %>
-  <%= post.thinking_core %>
-  <%= post.thinking_output %>
-</li>
+<% if @posts.any? %>
+  <ul class="posts-list">
+    <% @posts.each do |post| %>
+      <li>
+        <%= post.thinking_topic %>
+      </li>
+    <% end %>
+  </ul>
+<% else %>
+  <p>まだ投稿がありません。まずは今の気持ちを整理してみましょう！</p>
+  <%= link_to '思考を整理する', new_post_path %>
 <% end %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,0 +1,9 @@
+<h1>整理した思考一覧</h1>
+<% @posts.each do |post| %>
+<li>
+  <%= post.thinking_topic %>
+  <%= post.thinking_diffusion %>
+  <%= post.thinking_core %>
+  <%= post.thinking_output %>
+</li>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,5 +22,5 @@ Rails.application.routes.draw do
   # トップ画面（サイトのルートURL "/" にアクセスした時の設定）
   root "home#index"
 
-  resources :posts, only: [ :new, :create, :index]
+  resources :posts, only: [ :new, :create, :index ]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,5 +22,5 @@ Rails.application.routes.draw do
   # トップ画面（サイトのルートURL "/" にアクセスした時の設定）
   root "home#index"
 
-  resources :posts, only: [ :new, :create ]
+  resources :posts, only: [ :new, :create, :index]
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :user do
-    email { "test@example.com" }
+    sequence(:email) { |n| "test#{n}@example.com" } # test1@..., test2@... と被らない値を作る
     password { "password" }
     password_confirmation { "password" }
   end

--- a/spec/system/posts_spec.rb
+++ b/spec/system/posts_spec.rb
@@ -38,4 +38,38 @@ RSpec.describe "思考整理の投稿機能", type: :system do
       end
     end
   end
+
+  describe '投稿一覧機能', type: :system do
+    context '一覧表示の確認' do
+      # ログインユーザーの投稿を複数作成（let!で事前に作成）
+      let!(:my_post) { FactoryBot.create(:post, user: user, thinking_topic: '自分の投稿') }
+      let!(:old_post) { FactoryBot.create(:post, user: user, thinking_topic: '古い投稿', created_at: 1.day.ago) }
+      # 他人の投稿を作成
+      let!(:others_post) { FactoryBot.create(:post, thinking_topic: '他人の投稿') }
+
+      before do
+        visit posts_path
+      end
+
+      it 'ログインユーザーの投稿のみが表示され、他人の投稿は表示されないこと' do
+        expect(page).to have_content '自分の投稿'
+        expect(page).to have_content '古い投稿'
+        expect(page).not_to have_content '他人の投稿'
+      end
+
+      it '投稿が新しい順（作成日時の降順）に表示されていること' do
+        # 「自分の投稿」が「古い投稿」より上にあるか確認
+        # page.body.index を使うと、HTML内に出現する順番を数値で比較できる
+        expect(page.body.index('自分の投稿')).to be < page.body.index('古い投稿')
+      end
+    end
+
+    context '投稿がない場合' do
+      it '適切なメッセージが表示されること' do
+        visit posts_path
+        expect(page).to have_content 'まだ投稿がありません'
+        expect(page).to have_link '思考を整理する', href: new_post_path
+      end
+    end
+  end
 end


### PR DESCRIPTION
## 概要
投稿一覧ページを作成した。

## 背景・目的
作成した投稿の一覧を表示させる。

## 実施内容
- ルーティングにindex追加
- コントローラーにindexアクション追加
- ビュー作成
- ヘッダーにリンク追加
- テスト作成
  - ログインユーザーの投稿のみが表示され、他人の投稿は表示されないこと
  - 投稿が新しい順（作成日時の降順）に表示されていること
  - 投稿がない場合、適切なメッセージが表示されること

## 関連issue
Closes #14 