### PR TITLE
投稿詳細ページ作成

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -20,6 +20,10 @@ class PostsController < ApplicationController
     @posts = current_user.posts.includes(:user).order(created_at: :desc)
   end
 
+  def show
+    @post = current_user.posts.find(params[:id])
+  end
+
   private
 
   def post_params  # ストロングパラメータ

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -3,7 +3,7 @@
   <ul class="posts-list">
     <% @posts.each do |post| %>
       <li>
-        <%= post.thinking_topic %>
+        <%= link_to post.thinking_topic,  post_path(post) %>
       </li>
     <% end %>
   </ul>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,0 +1,23 @@
+<h1>思考の詳細</h1>
+
+<div>
+  <h3>整理したいテーマ</h3>
+  <p><%= @post.thinking_topic %></p>
+</div>
+
+<div>
+  <h3>考えの箇条書き</h3>
+  <p><%= simple_format(@post.thinking_diffusion) %></p>
+</div>
+
+<div>
+  <h3>整理の目的</h3>
+  <p><%= @post.thinking_core %></p>
+</div>
+
+<div>
+  <h3>整理した考え</h3>
+  <p><%= @post.thinking_output %></p>
+</div>
+
+<%= link_to '一覧に戻る', posts_path %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,5 +22,5 @@ Rails.application.routes.draw do
   # トップ画面（サイトのルートURL "/" にアクセスした時の設定）
   root "home#index"
 
-  resources :posts, only: [ :new, :create, :index ]
+  resources :posts, only: [ :new, :create, :index, :show ]
 end

--- a/spec/system/posts_spec.rb
+++ b/spec/system/posts_spec.rb
@@ -72,4 +72,24 @@ RSpec.describe "思考整理の投稿機能", type: :system do
       end
     end
   end
+
+  describe '投稿詳細機能', type: :system do
+    let!(:post) { FactoryBot.create(:post, user: user, thinking_topic: '詳細を見たいテーマ') }
+
+    before do
+      visit posts_path
+    end
+
+    it '一覧画面から詳細画面に遷移し、内容が表示されること' do
+      # 一覧画面のテーマ名をクリック
+      click_on '詳細を見たいテーマ'
+      # 詳細画面のURLに遷移しているか確認
+      expect(page).to have_current_path(post_path(post))
+      # 投稿の内容が表示されているか確認
+      expect(page).to have_content '詳細を見たいテーマ'
+      expect(page).to have_content post.thinking_diffusion
+      expect(page).to have_content post.thinking_core
+      expect(page).to have_content post.thinking_output
+    end
+  end
 end


### PR DESCRIPTION
## 概要
投稿詳細ページを作成した。

## 背景・目的
ユーザーが投稿内容を確認できるようにするため。

## 実施内容
- ルーティングにshowアクションを追加
- postsコントローラーにshowアクションを追加
- 投稿詳細ページのビューを作成
- 投稿一覧ページにリンク付け
- テスト作成、確認
  - [x]  一覧画面から詳細画面に遷移し、投稿内容が表示されること

## 関連Issue
Closes #16