### PR TITLE
投稿削除機能の実装

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -37,6 +37,12 @@ class PostsController < ApplicationController
     end
   end
 
+  def destroy
+    @post = current_user.posts.find(params[:id])
+    @post.destroy
+    redirect_to posts_path, notice: "投稿を削除しました"
+  end
+
   private
 
   def post_params  # ストロングパラメータ

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -22,5 +22,8 @@
 
 <div class="mt-6 flex gap-4">
   <%= link_to '編集', edit_post_path(@post), class: "bg-yellow-500 text-white py-2 px-4 rounded" %>
+  <%= link_to "削除", post_path(@post), 
+            class: "bg-red-500 text-white py-2 px-4 rounded",
+            data: { turbo_method: :delete, turbo_confirm: "投稿を削除してよろしいですか？" } %>
   <%= link_to '一覧に戻る', posts_path, class: "text-gray-500" %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,5 +22,5 @@ Rails.application.routes.draw do
   # トップ画面（サイトのルートURL "/" にアクセスした時の設定）
   root "home#index"
 
-  resources :posts, only: [ :new, :create, :index, :show, :edit, :update ]
+  resources :posts, only: [ :new, :create, :index, :show, :edit, :update, :destroy ]
 end

--- a/spec/system/posts_spec.rb
+++ b/spec/system/posts_spec.rb
@@ -120,4 +120,26 @@ RSpec.describe "思考整理の投稿機能", type: :system do
       end
     end
   end
+
+  describe "投稿削除機能", type: :system do
+    let!(:post) { FactoryBot.create(:post, user: user) }
+
+    before do
+      visit post_path(post)
+    end
+
+    it "投稿の削除が成功すること" do
+      # 削除ボタンを押して、ダイアログをOKする
+      page.accept_confirm do
+        click_on "削除"
+      end
+
+      # 一覧画面へ戻っているか確認
+      expect(page).to have_current_path(posts_path)
+      # 成功メッセージが出ているか確認
+      expect(page).to have_content "投稿を削除しました"
+      # 一覧から消えているか確認（タイトルが表示されていないこと）
+      expect(page).not_to have_content post.thinking_topic
+    end
+  end
 end

--- a/spec/views/posts/new.html.erb_spec.rb
+++ b/spec/views/posts/new.html.erb_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
 
 RSpec.describe "posts/new.html.erb", type: :view do
-  pending "add some examples to (or delete) #{__FILE__}"
+  # pending "add some examples to (or delete) #{__FILE__}"
 end


### PR DESCRIPTION
## 概要
投稿削除機能を実装した。
投稿詳細ページに削除ボタンを追加した。

## 背景・目的
ユーザーが投稿を削除できるようにするため。

## 実施内容

- ルーティングにdestroyアクション追加
- postsコントローラーにdestroyアクション追加
- 投稿詳細ページに投稿削除ボタンを設置
- 投稿削除機能のテスト作成、実施

  - [x] 投稿の削除が成功すること

## 関連Issue
Closes #38 