### PR TITLE
レスポンシブ対応（スマホ向けハンバーガーメニューの実装）

### DIFF
--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -6,3 +6,6 @@ import { application } from "./application"
 
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)
+
+import MenuController from "./menu_controller"
+application.register("menu", MenuController)

--- a/app/javascript/controllers/menu_controller.js
+++ b/app/javascript/controllers/menu_controller.js
@@ -1,0 +1,9 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["nav"]
+
+  toggle() {
+    this.navTarget.classList.toggle("hidden")
+  }
+}

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -20,28 +20,33 @@
       <!-- アクションボタン -->
       <div class="flex items-center gap-3">
         <% if user_signed_in? %>
-          <button class="sm:hidden p-2 text-gray-500 hover:text-gray-700"
-                  data-action="click->menu#toggle"
-                  aria-label="メニューを開く">
-            <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
-            </svg>
-          </button>
+
+          <!-- ハンバーガーボタン + ドロップダウン (スマホのみ) -->
+          <div class="relative sm:hidden">
+            <button class="p-2 text-gray-500 hover:text-gray-700"
+                    data-action="click->menu#toggle"
+                    aria-label="メニューを開く">
+              <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+              </svg>
+            </button>
+
+            <div class="hidden absolute right-0 top-full mt-2 w-48 bg-white rounded-lg shadow-lg border border-gray-100 py-1 z-50"
+              data-menu-target="nav">
+              <%= link_to "思考整理", new_post_path, class: "block px-4 py-2.5 text-sm text-gray-600 hover:text-gray-900 hover:bg-gray-50 transition" %>
+              <%= link_to "思考一覧", posts_path, class: "block px-4 py-2.5 text-sm text-gray-600 hover:text-gray-900 hover:bg-gray-50 transition" %>
+              <div class="border-t border-gray-100 my-1"></div>
+              <%= link_to "ログアウト", destroy_user_session_path, data: { turbo_method: "delete" }, class: "block px-4 py-2.5 text-sm text-red-500 hover:text-red-700 hover:bg-red-50 transition" %>
+            </div>
+          </div>
+
           <%= link_to "ログアウト", destroy_user_session_path, data: { turbo_method: "delete" }, class: "hidden sm:block text-sm font-medium text-white px-4 py-2 rounded-md transition", style: "background-color: #47a971;" %>
+
         <% else %>
           <%= link_to "ログイン", new_user_session_path, class: "text-sm font-medium px-4 py-2 rounded-md border transition", style: "color: #47a971; border-color: #47a971;" %>
           <%= link_to "新規登録", new_user_registration_path, class: "text-sm font-medium text-white px-4 py-2 rounded-md transition", style: "background-color: #47a971;" %>
         <% end %>
       </div>
     </div>
-
-    <!-- スマホ用ドロップダウンメニュー -->
-    <% if user_signed_in? %>
-      <div class="hidden sm:hidden flex flex-col pb-4 border-t border-gray-100" data-menu-target="nav">
-        <%= link_to "思考整理", new_post_path, class: "block px-2 py-3 text-sm text-gray-600 hover:text-gray-900 hover:bg-gray-50 rounded-md transition" %>
-        <%= link_to "思考一覧", posts_path, class: "block px-2 py-3 text-sm text-gray-600 hover:text-gray-900 hover:bg-gray-50 rounded-md transition" %>
-        <%= link_to "ログアウト", destroy_user_session_path, data: { turbo_method: "delete" }, class: "text-sm font-medium text-white px-4 py-2 rounded-md transition", style: "background-color: #47a971;" %>
-      </div>
-    <% end %>
   </nav>
 </header>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,4 +1,4 @@
-<header class="bg-white border-b border-gray-100">
+<header class="bg-white border-b border-gray-100" data-controller="menu">
   <nav class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8" aria-label="Top">
     <div class="flex w-full items-center justify-between py-4">
       <div class="flex items-center">
@@ -13,11 +13,6 @@
         <% if user_signed_in? %>
           <%= link_to "思考整理", new_post_path, class: "text-sm text-gray-400 hover:text-gray-700 transition" %>
           <%= link_to "思考一覧", posts_path, class: "text-sm text-gray-400 hover:text-gray-700 transition" %>
-          <%# link_to "利用規約", "#", class: "text-sm text-gray-400 hover:text-gray-700 transition" %>
-          <%# link_to "プライバシーポリシー", "#", class: "text-sm text-gray-400 hover:text-gray-700 transition" %>
-        <% else %>
-          <%# link_to "利用規約", "#", class: "text-sm text-gray-400 hover:text-gray-700 transition" %>
-          <%# link_to "プライバシーポリシー", "#", class: "text-sm text-gray-400 hover:text-gray-700 transition" %>
         <% end %>
         </div>
       </div>
@@ -25,12 +20,28 @@
       <!-- アクションボタン -->
       <div class="flex items-center gap-3">
         <% if user_signed_in? %>
-          <%= link_to "ログアウト", destroy_user_session_path, data: { turbo_method: "delete" }, class: "text-sm font-medium text-white px-4 py-2 rounded-md transition", style: "background-color: #47a971;" %>
+          <button class="sm:hidden p-2 text-gray-500 hover:text-gray-700"
+                  data-action="click->menu#toggle"
+                  aria-label="メニューを開く">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+            </svg>
+          </button>
+          <%= link_to "ログアウト", destroy_user_session_path, data: { turbo_method: "delete" }, class: "hidden sm:block text-sm font-medium text-white px-4 py-2 rounded-md transition", style: "background-color: #47a971;" %>
         <% else %>
           <%= link_to "ログイン", new_user_session_path, class: "text-sm font-medium px-4 py-2 rounded-md border transition", style: "color: #47a971; border-color: #47a971;" %>
           <%= link_to "新規登録", new_user_registration_path, class: "text-sm font-medium text-white px-4 py-2 rounded-md transition", style: "background-color: #47a971;" %>
         <% end %>
       </div>
     </div>
+
+    <!-- スマホ用ドロップダウンメニュー -->
+    <% if user_signed_in? %>
+      <div class="hidden sm:hidden flex flex-col pb-4 border-t border-gray-100" data-menu-target="nav">
+        <%= link_to "思考整理", new_post_path, class: "block px-2 py-3 text-sm text-gray-600 hover:text-gray-900 hover:bg-gray-50 rounded-md transition" %>
+        <%= link_to "思考一覧", posts_path, class: "block px-2 py-3 text-sm text-gray-600 hover:text-gray-900 hover:bg-gray-50 rounded-md transition" %>
+        <%= link_to "ログアウト", destroy_user_session_path, data: { turbo_method: "delete" }, class: "text-sm font-medium text-white px-4 py-2 rounded-md transition", style: "background-color: #47a971;" %>
+      </div>
+    <% end %>
   </nav>
 </header>


### PR DESCRIPTION
## 概要
レスポンシブ対応。スマホ向けハンバーガーメニューを実装した。

## 背景

スマホ表示時にヘッダーのナビゲーションリンク（思考整理・思考一覧）が非表示となっており、主要機能へのアクセス手段がなかった。

## 変更内容

- スマホ時（640px未満）にハンバーガーボタン（≡）を表示
- ボタンタップでカード型ドロップダウンを開閉（Stimulus の `MenuController` で制御）
- ドロップダウン内に「思考整理」「思考一覧」「ログアウト」を配置
- PC表示は従来の横並びナビ＋ログアウトボタンをそのまま維持

## 変更ファイル

| ファイル | 内容 |
|---|---|
| `app/javascript/controllers/menu_controller.js` | 新規作成。`toggle()` で `hidden` クラスの付け外しを制御 |
| `app/javascript/controllers/index.js` | `MenuController` を登録 |
| `app/views/layouts/_header.html.erb` | ハンバーガーボタンとドロップダウンを追加 |

## 動作確認

- [x] スマホ幅でハンバーガーボタンが表示される
- [x] タップでドロップダウンが開閉する
- [x] 各リンク（思考整理・思考一覧・ログアウト）が機能する
- [x] PC幅では従来のヘッダー表示が維持される

##関連Issue
closes #99 