### PR TITLE
CI のテスト実行ステップを RSpec で有効化

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -70,6 +70,23 @@ jobs:
           ruby-version: .ruby-version
           bundler-cache: true
 
+      # Node を用意（本番 Dockerfile と同じバージョンに揃えるため .node-version=24.14.1 を参照）
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .node-version   # ランナー既定ではなくファイル指定でバージョン固定
+          cache: yarn                        # yarn.lock を鍵に依存をキャッシュして高速化
+
+      # JS 依存を yarn.lock 通りに厳密インストール（勝手な更新を禁止＝本番と同じ挙動）
+      - name: Install JS dependencies
+        run: yarn install --frozen-lockfile
+
+      # アセットを生成。これが無いと request/system spec が application.css を見つけられず落ちる。
+      - name: Build assets
+        run: |
+          yarn build      # esbuild で JS を app/assets/builds/application.js に生成
+          yarn build:css  # @tailwindcss/cli で CSS を app/assets/builds/application.css に生成
+
       - name: Run tests
         env:
           RAILS_ENV: test

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -70,12 +70,14 @@ jobs:
           ruby-version: .ruby-version
           bundler-cache: true
 
-      # - name: Run tests
-      #   env:
-      #     RAILS_ENV: test
-      #     DATABASE_URL: postgres://postgres:postgres@localhost:5432
-      #     # REDIS_URL: redis://localhost:6379/0
-      #   run: bin/rails db:test:prepare test test:system
+      - name: Run tests
+        env:
+          RAILS_ENV: test
+          DATABASE_URL: postgres://postgres:postgres@localhost:5432
+          # REDIS_URL: redis://localhost:6379/0
+        run: |
+          bin/rails db:test:prepare
+          bundle exec rspec
 
       - name: Keep screenshots from failed system tests
         uses: actions/upload-artifact@v4

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -72,13 +72,4 @@ RSpec.configure do |config|
 
   # request spec でも sign_in/sign_out が使えるようになる
   config.include Devise::Test::IntegrationHelpers, type: :request
-
-  config.before(:each, type: :system) do
-    driven_by :remote_chrome
-
-    Capybara.server_host = IPSocket.getaddress(Socket.gethostname)
-    Capybara.server_port = 4444
-    Capybara.app_host = "http://#{Capybara.server_host}:#{Capybara.server_port}"
-    Capybara.ignore_hidden_elements = false
-  end
 end

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,8 +1,43 @@
-Capybara.register_driver :remote_chrome do |app|
-  options = Selenium::WebDriver::Chrome::Options.new
-  options.add_argument('no-sandbox')
-  options.add_argument('headless')
-  options.add_argument('disable-gpu')
-  options.add_argument('window-size=1680,1050')
-  Capybara::Selenium::Driver.new(app, browser: :remote, url: ENV['SELENIUM_DRIVER_URL'], capabilities: options)
+require "capybara/rspec"                                  # Capybara の RSpec 連携を読み込む
+require "selenium-webdriver"                              # Selenium を読み込み、Selenium::WebDriver 系の定数を使えるようにする
+
+Capybara.default_max_wait_time = 10                       # 要素待ちの上限を10秒に。CIの高負荷で間欠失敗するのを防ぐ（成功テストには無害）
+
+# --- docker開発環境用ドライバ：別コンテナのChromeにリモート接続 ---
+Capybara.register_driver :remote_chrome do |app|          # :remote_chrome という名前でドライバを登録。app=テスト対象のRackアプリ
+  options = Selenium::WebDriver::Chrome::Options.new      # Chrome の起動オプションを組み立てる入れ物を作る
+  options.add_argument("no-sandbox")                      # サンドボックス無効化（コンテナ内でChromeを動かすのに必要）
+  options.add_argument("headless")                        # 画面なし（ヘッドレス）で起動
+  options.add_argument("disable-gpu")                     # GPUアクセラレーション無効（ヘッドレスでの安定化）
+  options.add_argument("window-size=1680,1050")           # 仮想ウィンドウのサイズを指定
+  Capybara::Selenium::Driver.new(                         # このドライバの実体を生成（ブロックの戻り値＝登録内容になる）
+    app,                                                  # テスト対象アプリ
+    browser: :remote,                                     # 「リモートのChromeに繋ぐ」モード
+    url: ENV["SELENIUM_DRIVER_URL"],                      # 繋ぎ先＝docker の chrome コンテナ(:4444)
+    capabilities: options                                 # 上で作ったオプションを適用
+  )
+end
+
+# --- CI/ローカル直接実行用ドライバ：その場でChromeを起動 ---
+Capybara.register_driver :headless_chrome do |app|        # :headless_chrome という名前で別のドライバを登録
+  options = Selenium::WebDriver::Chrome::Options.new      # 同じくオプションの入れ物を作る
+  options.add_argument("--headless=new")                  # ヘッドレスで起動（Chrome現行の推奨形）
+  options.add_argument("--no-sandbox")                    # サンドボックス無効化（CIランナーで必要）
+  options.add_argument("--disable-gpu")                   # GPU無効
+  options.add_argument("--window-size=1680,1050")         # ウィンドウサイズ指定
+  Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)  # browser: :chrome＝同じマシンのChromeを直接起動（remoteではない）
+end
+
+RSpec.configure do |config|                               # RSpec全体の設定
+  config.before(:each, type: :system) do                  # system spec の各テスト直前に、この中を実行する
+    if ENV["SELENIUM_DRIVER_URL"].present?                # 環境変数がある＝docker環境か判定
+      driven_by :remote_chrome                            # dockerの場合、リモートのChromeコンテナを使う
+      Capybara.server_host = IPSocket.getaddress(Socket.gethostname)  # テスト用アプリを、別コンテナのChromeから届くIPで公開
+      Capybara.server_port = 4444                         # そのアプリのポートを固定
+      Capybara.app_host = "http://#{Capybara.server_host}:#{Capybara.server_port}"  # ChromeがアクセスすべきアプリのURLを組み立てる
+    else                                                  # 環境変数が無い＝CI/ローカル直接実行
+      driven_by :headless_chrome                          # その場のChromeを使う（server_host等はCapybara既定に任せる）
+    end
+    Capybara.ignore_hidden_elements = false               # 非表示要素も操作対象に含める（両環境共通の設定）
+  end
 end


### PR DESCRIPTION
## 概要
ci-cd.ymlのテスト実行ステップがコメントアウトされており、
自動テストが走らないまま deploy が素通りしていた。
RSpec 用コマンドに置き換えて有効化し、メジャーアップグレード前の安全網を確保する。

## 変更内容
- `Run tests` ステップのコメントアウトを解除
- `bin/rails db:test:prepare test test:system`（Minitest用）を
  `bin/rails db:test:prepare && bundle exec rspec` に変更

## 関連issue
closes #138 