### PR TITLE
Rails EOLエラーを一時的に無効にする

### DIFF
--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,0 +1,24 @@
+{
+  "ignored_warnings": [
+    {
+      "warning_type": "Unmaintained Dependency",
+      "warning_code": 122,
+      "fingerprint": "21ab0fe00fdd5899ffc405cff75aadb91b805ee996a614f7e27b08a287e9062d",
+      "check_name": "EOLRails",
+      "message": "Support for Rails 7.2.3.1 ends on 2026-08-09",
+      "file": "Gemfile.lock",
+      "line": 493,
+      "link": "https://brakemanscanner.org/docs/warning_types/unmaintained_dependency/",
+      "code": null,
+      "render_path": null,
+      "location": null,
+      "user_input": null,
+      "confidence": "Weak",
+      "cwe_id": [
+        1104
+      ],
+      "note": "Rails7.2のEOL警告。 本リリース後にアップグレードするまで既知の警告として無視する。"
+    }
+  ],
+  "brakeman_version": "8.0.5"
+}


### PR DESCRIPTION
## 概要

CI の `scan_ruby` ジョブ（Brakeman）で発生していた **Rails 7.2 の EOL 警告**を、`config/brakeman.ignore` に note 付きで登録して解消。全ジョブが green になる状態にした。

## 背景・目的

- Brakeman `8.0.5` の `EOLRails` チェックが Rails 7.2.3.1 を EOL と判定
- Rails アップグレード（根本対応）は別 Issue とし、本 PR では**既知の警告を管理下に置いて CI を通す**ことを目的とする
  - `--except EOLRails`（チェック丸ごと無効化）は、将来の新規 EOL を静かに見逃すため採用しない
  - `brakeman.ignore` なら **警告1件だけ**を note 付きで無視でき、根本対応のリマインドも兼ねられる

## 実施内容

- `bin/brakeman -I`（インタラクティブモード）で EOL 警告を無視リストに追加
- `config/brakeman.ignore` を新規追加し、`note` に「Rails 7.2 は EOL のため警告。アップグレードは別 Issue で根本対応予定」を記載
- `ci-cd.yml` は変更なし（既存の `bin/brakeman --no-pager` のまま）
- ローカル（Docker `web` コンテナ）で `bin/brakeman` の **exit 0** を確認

## 関連Issue

Closes #142 