### PR TITLE
ログイン・新規登録ボタン位置をワークフロー説明の下に変更

### DIFF
--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -6,26 +6,20 @@
     <p class="text-2xl font-bold mb-3" style="color: #47a971;">
       「また、うまく伝えられなかった…。」
     </p>
-<p class="text-base font-medium text-gray-500 mb-10 text-left max-w-xs mx-auto">
-  ― もしかすると、思考を整理する前に<br>
-  <span class="pl-20">話を始めたからかもしれません。</span>
-</p>
+    <p class="text-base font-medium text-gray-500 mb-10 text-left max-w-xs mx-auto">
+      ― もしかすると、思考を整理する前に<br>
+      <span class="pl-20">話を始めたからかもしれません。</span>
+    </p>
     <!-- 1. サービス概要セクション（ヒーローエリア）-->
     <p class="text-base text-gray-500 leading-relaxed mb-10 text-left md:text-center">
       「何を相談すればいいか分からない」「意見をうまく伝えられない」<br>
       そんな悩みを持つ人のための、思考整理アプリです。<br>
       フォームに沿って入力し、AIに整理を任せるだけで、すっきりした考えが手に入ります。
     </p>
-    <div class="flex justify-center gap-4">
-      <% unless user_signed_in? %>
-        <%= link_to "無料で始める（新規登録）", new_user_registration_path, class: "px-6 py-2.5 text-sm font-medium text-white rounded-md transition", style: "background-color: #47a971;" %>
-        <%= link_to "ログイン", new_user_session_path, class: "px-6 py-2.5 text-sm font-medium rounded-md border transition", style: "color: #47a971; border-color: #47a971;" %>
-      <% end %>
-    </div>
   </div>
 </div>
 
-<!-- # 2. 最初の一歩（ワークフロー）-->
+<!-- 2. 最初の一歩（ワークフロー）-->
 <div class="py-16 bg-white">
   <div class="max-w-5xl mx-auto px-4">
     <h2 class="text-xl font-medium text-center mb-10 text-gray-800">思考整理のステップ</h2>
@@ -60,6 +54,18 @@
       </div>
     </div>
 
-    <p class="text-xs text-center text-gray-400 mt-8">報連相だけでなく、学びの整理・会議の振り返り・モヤモヤの言語化など、さまざまな場面でお使いいただけます。まずは気軽に試してみてください。</p>
+    <p class="text-xm text-center text-gray-400 mt-8">
+      報連相だけでなく、学びの整理・会議の振り返り・モヤモヤの言語化など、さまざまな場面でお使いいただけます。<br>
+      まずは気軽に試してみてください。
+    </p>
+
+    <div class="flex justify-center gap-4 mt-8">
+      <% unless user_signed_in? %>
+        <%= link_to "無料で始める（新規登録）", new_user_registration_path, class: "px-6 py-2.5 text-sm font-medium text-white rounded-md transition", style: "background-color: #47a971;" %>
+        <%= link_to "ログイン", new_user_session_path, class: "px-6 py-2.5 text-sm font-medium rounded-md border transition", style: "color: #47a971; border-color: #47a971;" %>
+      <% end %>
+    </div>
+
   </div>
 </div>
+


### PR DESCRIPTION
## 概要
ワークフロー（思考整理ステップの説明）下にログイン、新規登録ボタンを配置変更した。

## 背景・目的
ユーザー登録フロー（変更前）
・ヒーローエリア確認→下スクロール→ワークフロー確認→**上スクロール**→ヒーローエリア内の「新規登録ボタン」をクリック

ワークフロー（思考整理ステップの説明）確認後すぐに新規登録ボタンを押せるように変更する。
（上スクロールの手間を排除、ユーザー負荷軽減）
ログインユーザーはヘッダーのログインボタンからすぐにログイン可能。

## 実施内容
 - app\views\home\index.html.erb
   - ログイン、新規登録ボタンをワークフロー下に配置変更

## 関連Issue
Closes #98 