### PR TITLE
オートログイン後の遷移先を新規作成ページに変更（ルートのログイン状態別出し分け）

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -18,7 +18,7 @@
       <!-- アクションボタン -->
       <div class="flex items-center gap-3">
         <% if user_signed_in? %>
-
+        
           <!-- ハンバーガーボタン + ドロップダウン (スマホのみ) -->
           <div class="relative sm:hidden">
             <button class="p-2 text-gray-500 hover:text-gray-700"

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -4,9 +4,7 @@
       <div class="flex items-center">
 
         <!-- ロゴ -->
-        <%= link_to root_path do %>
-          <span class="text-lg font-bold tracking-wide" style="color: #47a971;">Output JON</span>
-        <% end %>
+        <%= link_to "Output JON", "/", class: "text-lg font-bold tracking-wide", style: "color: #47a971;" %>
 
         <!-- ナビゲーションリンク (デスクトップ) -->
         <div class="ml-10 hidden space-x-6 sm:block">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,11 +20,13 @@ Rails.application.routes.draw do
   get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
   get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
 
-  # ルート パス ("/") を以下のように定義します。
-  # root "posts#index"
+  authenticated :user do
+    root to: "posts#new", as: :authenticated_root
+  end
 
-  # トップ画面（サイトのルートURL "/" にアクセスした時の設定）
-  root "home#index"
+  unauthenticated do
+    root to: "home#index", as: :unauthenticated_root
+  end
 
   resources :posts, only: [ :new, :create, :index, :show, :edit, :update, :destroy ] do
     member do

--- a/spec/requests/root_spec.rb
+++ b/spec/requests/root_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+RSpec.describe "ルートパスの出し分け", type: :request do
+  
+  describe "GET /" do
+    context "未ログイン時" do                          # home#indexページが表示されること
+      before { get "/" }
+      
+      it "HTTPステータス200を返す" do                                    
+        expect(response).to have_http_status(200)
+      end
+      
+      it "ログインへのリンクが含まれる" do
+        expect(response.body).to include(new_user_session_path)
+      end
+
+      it "新規登録へのリンクが含まれる" do
+        expect(response.body).to include(new_user_registration_path)
+      end
+      
+      it "リード文が含まれる" do
+        expect(response.body).to include("「また、うまく伝えられなかった…。」")
+      end
+
+    end
+
+    context "ログイン時" do                            # posts#new
+    let(:user) { FactoryBot.create(:user) }
+    before do
+      sign_in user     
+      get "/"
+    end
+      
+      it "HTTPステータス200を返す" do                                    
+        expect(response).to have_http_status(200)
+      end
+      
+      it "ログアウトのリンクが含まれる" do
+        expect(response.body).to include(destroy_user_session_path)
+      end
+      
+      it "ページタイトルが含まれる" do
+        expect(response.body).to include("思考の整理")
+      end
+      
+    end
+  end
+end

--- a/spec/requests/root_spec.rb
+++ b/spec/requests/root_spec.rb
@@ -1,15 +1,14 @@
 require 'rails_helper'
 
 RSpec.describe "ルートパスの出し分け", type: :request do
-  
   describe "GET /" do
     context "未ログイン時" do                          # home#indexページが表示されること
       before { get "/" }
-      
-      it "HTTPステータス200を返す" do                                    
+
+      it "HTTPステータス200を返す" do
         expect(response).to have_http_status(200)
       end
-      
+
       it "ログインへのリンクが含まれる" do
         expect(response.body).to include(new_user_session_path)
       end
@@ -17,32 +16,30 @@ RSpec.describe "ルートパスの出し分け", type: :request do
       it "新規登録へのリンクが含まれる" do
         expect(response.body).to include(new_user_registration_path)
       end
-      
+
       it "リード文が含まれる" do
         expect(response.body).to include("「また、うまく伝えられなかった…。」")
       end
-
     end
 
     context "ログイン時" do                            # posts#new
     let(:user) { FactoryBot.create(:user) }
     before do
-      sign_in user     
+      sign_in user
       get "/"
     end
-      
-      it "HTTPステータス200を返す" do                                    
+
+      it "HTTPステータス200を返す" do
         expect(response).to have_http_status(200)
       end
-      
+
       it "ログアウトのリンクが含まれる" do
         expect(response.body).to include(destroy_user_session_path)
       end
-      
+
       it "ページタイトルが含まれる" do
         expect(response.body).to include("思考の整理")
       end
-      
     end
   end
 end

--- a/spec/system/headers_spec.rb
+++ b/spec/system/headers_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "ヘッダー", type: :system do
   describe "表示の確認" do
     context "未ログイン時" do
       it "「ログイン」、「新規登録」が表示されること" do
-        visit root_path
+        visit unauthenticated_root_path
         expect(page).to have_link('ログイン')
         expect(page).to have_link('新規登録')
       end
@@ -31,7 +31,7 @@ RSpec.describe "ヘッダー", type: :system do
       click_link 'ログアウト', visible: true
       # ログアウト後の検証
       expect(page).to have_content ('Signed out successfully.')
-      expect(current_path).to eq root_path
+      expect(page).to have_current_path(unauthenticated_root_path)
       expect(page).to have_link ('ログイン')
     end
   end
@@ -40,7 +40,7 @@ RSpec.describe "ヘッダー", type: :system do
     it 'ヘッダーのロゴをクリックしたとき、ルートページへ遷移すること' do
       visit new_user_session_path # 別のページから遷移することを確認するため、あえて別の場所へ
       click_on('Output JON')
-      expect(page).to have_current_path(root_path)
+      expect(page).to have_current_path(unauthenticated_root_path)
     end
   end
 end


### PR DESCRIPTION
## 概要
オートログイン（Devise rememberable）で再訪問したユーザーが、トップ `/` から
新規作成ページ（posts#new）へ遷移するよう、ルートをログイン状態で出し分けました。

## 背景・課題
- オートログイン自体は Devise の rememberable で有効化済み。
- ただし再訪問時の `/` は常にトップ（home#index）を表示していたため、
  「オートログイン後は思考の整理をすぐ始めたい」という体験に繋がっていなかった。

## 変更内容
- `config/routes.rb`
  - `authenticated :user` → `root: posts#new`
  - `unauthenticated` → `root: home#index`
  - 素の `root` を廃し、`authenticated_root` / `unauthenticated_root` に分割
- `app/views/layouts/_header.html.erb`
  - ロゴのリンク先を `"/"` に変更（環境非依存。遷移先はルーティングが判定）
- テスト
  - `spec/requests/root_spec.rb`（新規）: `/` の出し分けを検証
    - 未ログイン → home#index（ログイン/新規登録リンク・リード文）
    - ログイン → posts#new（ログアウトリンク・"思考の整理"）
  - `spec/system/headers_spec.rb`: `root_path` 廃止に伴い `unauthenticated_root_path` へ追従

## 動作確認
- ローカルで remember cookie による自動ログインを確認（セッションcookie削除後もログイン維持）
- 未ログイン `/` → home、ログイン `/` → posts#new を目視確認

## テスト観点・補足
- オートログインの仕組み自体は Devise の責務のためテスト対象外。
  本PRでは「自作したルーティングの出し分け」を request spec で担保。

## 関連 Issue
Close #97